### PR TITLE
Fix player Corner Box and Healthbar

### DIFF
--- a/7DTD/Drawing.cs
+++ b/7DTD/Drawing.cs
@@ -22,6 +22,41 @@ namespace Cheat
         }
         private static Material drawMaterial;
 
+        public static void DrawHealthBar(EntityAlive entity, float height, float x, float y)
+        {
+            float maxHealth = entity.Stats.Health.Max;
+            float curHealth = entity.Stats.Health.Value;
+            float percentage = curHealth / (float)maxHealth;
+            float barHeight = height * percentage;
+            Color32 barColour = GetHealthColour(entity);
+            DrawFilledBox(x - 5f, y, 4f, height, new Color32(0, 0, 0, 180)); // draw health bar background
+            DrawFilledBox(x - 4f, y + height - barHeight - 1f, 2f, barHeight, barColour); // draw healthbar
+        }
+        private static Color32 GetHealthColour(EntityAlive entity)
+        {
+            float maxhp = entity.Stats.Health.Max;
+            float hp = entity.Stats.Health.Value;
+            float percent2 = (hp / maxhp) * 100;
+            Color32 barcol = new Color32();
+            if (percent2 <= 100 && percent2 >= 86)
+            {
+                barcol = new Color32(15, 212, 10, 255);
+            }
+            if (percent2 <= 85 && percent2 >= 66)
+            {
+                barcol = new Color32(253, 219, 9, 200);
+
+            }
+            if (percent2 <= 65 && percent2 >= 35)
+            {
+                barcol = new Color32(249, 108, 24, 200);
+            }
+            if (percent2 <= 34 && percent2 >= 0)
+            {
+                barcol = new Color32(249, 3, 3, 255);
+            }
+            return barcol;
+        }
         public static void DrawCircle(Color Col, Vector2 Center, float Radius)
         {
             GL.PushMatrix();

--- a/7DTD/Esp/Player.cs
+++ b/7DTD/Esp/Player.cs
@@ -53,14 +53,12 @@ namespace Cheat.Esp
 
         }
         void OnGUI1()
-        {   
-           
+        {
             if (Globals.LocalPlayer != null)
             {
                 EntityAlive ent = Globals.LocalPlayer as EntityAlive;
                 Vector3 lookdirection = new Vector3(0f, ent.GetEyeHeight(), 0f);
                 Vector3 lookvector = ent.GetLookVector();
-         
             }
             try
             {
@@ -93,42 +91,19 @@ namespace Cheat.Esp
                     if ((player.IsAdmin || player.IsSpectator) && Globals.Config.Player.ShowAdmins)
                         Drawing.DrawString(new Vector2(screenposition.x, screenposition.y + 10), $"Admin", Helpers.ColourHelper.GetColour("Player Colour"), true, 11, FontStyle.Normal, 3); // draw admin status
 
-                   if (Globals.Config.Player.Chams)
+                    if (Globals.Config.Player.Chams)
                         Helpers.ShaderHelper.ApplyShader(Helpers.ShaderHelper.Shaders["Chams"], player.gameObject, Helpers.ColourHelper.GetColour("Player Chams Visible Colour"), Helpers.ColourHelper.GetColour("Player Chams Invisible Colour")); // apply chams
 
-                    float height = Mathf.Abs(screenposition.y - screenposition.y); // get the height difference
+                    float height = Mathf.Abs(headposition.y - screenposition.y); // get the height difference
+                    float x = screenposition.x - height * 0.3f;
+                    float y = headposition.y; 
                     if (Globals.Config.Player.Box && distance < 200)
                     {
-                       
                         Drawing.PlayerCornerBox(new Vector2(headposition.x, headposition.y + 0.5f), height / 2, height, 2, distance, Helpers.ColourHelper.GetColour("Player Box Colour")); // draw a corner box
                     }
                     if (Globals.Config.Player.HealthBar && distance < 200)
                     {
-                        float maxhp = player.Stats.Health.Max;
-                        float hp = player.Stats.Health.Value;
-                        float percent = hp / maxhp;
-                        float percent2 = (hp / maxhp) * 100;
-                        float use = percent * height - 2f;
-                        Color32 barcol = new Color32();
-                        if (percent2 <= 100 && percent2 >= 86)
-                        {
-                            barcol = new Color32(15, 212, 10, 255);
-                        }
-                        if (percent2 <= 85 && percent2 >= 66)
-                        {
-                            barcol = new Color32(253, 219, 9, 200);
-
-                        }
-                        if (percent2 <= 65 && percent2 >= 35)
-                        {
-                            barcol = new Color32(249, 108, 24, 200);
-                        }
-                        if (percent2 <= 34 && percent2 >= 0)
-                        {
-                            barcol = new Color32(249, 3, 3, 255);
-                        }
-                        Drawing.DrawFilledBox(headposition.x - height / 4 - 5, headposition.y, 4, height, new Color32(0, 0, 0, 180)); // draw health bar background
-                        Drawing.DrawFilledBox(headposition.x - height / 4 - 4, headposition.y + height - use - 1, 2f, use, barcol); // draw healthbar
+                        Drawing.DrawHealthBar(player, height, x, y);
                     }
                 }
             }


### PR DESCRIPTION
Fixed screen positions and switched place for DrawHealthBar to Drawing and as a Parameter used EntityAlive so if neede it can be used for Enemies as well